### PR TITLE
Create text input component

### DIFF
--- a/packages/planes-ds/src/lib/components/atoms/input/Input.stories.tsx
+++ b/packages/planes-ds/src/lib/components/atoms/input/Input.stories.tsx
@@ -9,6 +9,13 @@ export default {
 //Arguments for input
 const InputArgs = args => <Input {...args} />
 
+//Text Input Component
+export const Text = InputArgs.bind({})
+Text.args = {
+    placeholder: "Text Input Component",
+    maxLength: 200,
+}
+
 //Decimal Value
 export const DecimalValue = InputArgs.bind({})
 DecimalValue.args = {
@@ -19,12 +26,6 @@ DecimalValue.args = {
 export const IntegerValue = InputArgs.bind({})
 IntegerValue.args = {
     placeholder: "21",
-}
-
-//Text
-export const Text = InputArgs.bind({})
-Text.args = {
-    placeholder: "Base Text",
 }
 
 //Alphabetic Text


### PR DESCRIPTION
I have added a text input component that has no restrictions. You can edit the length using a parameter in Storybook. By default, the length is set to 200.

# :sparkles: Create text input component

## Description

I have added a text input component with the following features:
- No character restrictions by default.
- Adjustable length using a parameter in Storybook, with a default length of 200 characters.

## Related JIRA Tickets

<!-- If this pull request is related to any JIRA tickets, list them here with the corresponding ticket numbers. -->

- [PROJ-123](https://your-jira-domain.com/browse/PROJ-123)
- [PROJ-456](https://your-jira-domain.com/browse/PROJ-456)

## Changes
- Created a new "TextInput" component.
- Added parameter support for adjusting the maximum character length.
- Set the default maximum length to 200 characters.

## Checklist

<!-- Mark the items that apply to this pull request. You can add more items if needed. -->

- [x] I have tested my changes thoroughly.
- [x] I have updated the documentation to reflect the changes.
- [ ] I have added unit tests (if applicable) to cover the changes.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have rebased my branch on the latest main/development branch.
- [x] All existing tests are passing.
- [x] I have run the linter and addressed any warnings or errors.
- [x] I have self-reviewed my code to catch potential issues.
- [x] I have considered the potential impact of these changes on other parts of the monorepo.
- [x] I have tested these changes in a local environment.
