### PR TITLE
:lipstick: Add Integer input

### DIFF
--- a/packages/planes-ds/package-lock.json
+++ b/packages/planes-ds/package-lock.json
@@ -16,7 +16,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tailwind-merge": "^1.14.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@babel/core": "7.22.10",
@@ -19268,6 +19269,14 @@
       },
       "optionalDependencies": {
         "commander": "^10.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/packages/planes-ds/package.json
+++ b/packages/planes-ds/package.json
@@ -36,7 +36,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwind-merge": "^1.14.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@babel/core": "7.22.10",

--- a/packages/planes-ds/src/lib/components/atoms/input/Input.stories.tsx
+++ b/packages/planes-ds/src/lib/components/atoms/input/Input.stories.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { Input } from './index';
 import ComponentResolver from './componentResolver';
-import { validate } from './validate'
-import {validate_Input} from './validate'
 import { IntegerInput } from './integerInput';
 
 export default {
@@ -15,7 +13,6 @@ export default {
         }
     }
 }
-validate();
 
 const Template = (args) => <ComponentResolver {...args} />; //Arguments for component resolver
 
@@ -32,8 +29,8 @@ Alphabetic.args = {
     inputType: 'alphabetic',
 };
 
-export const Integer_Second = IntegerInputArgs.bind({});
-Integer_Second.args = {
+export const Integer = IntegerInputArgs.bind({});
+Integer.args = {
     inputType: 'Integer',
     //type: 'number',
     placeholder: "123",

--- a/packages/planes-ds/src/lib/components/atoms/input/Input.stories.tsx
+++ b/packages/planes-ds/src/lib/components/atoms/input/Input.stories.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { Input } from './index';
 import ComponentResolver from './componentResolver';
+import { validate } from './validate'
+import {validate_Input} from './validate'
+import { IntegerInput } from './integerInput';
 
 export default {
     title: "Input",
@@ -12,8 +15,12 @@ export default {
         }
     }
 }
+validate();
 
 const Template = (args) => <ComponentResolver {...args} />; //Arguments for component resolver
+
+const IntegerInputArgs = args => <IntegerInput {...args} />
+
 
 export const Text = Template.bind({});
 Text.args = {
@@ -23,4 +30,12 @@ Text.args = {
 export const Alphabetic = Template.bind({});
 Alphabetic.args = {
     inputType: 'alphabetic',
+};
+
+export const Integer_Second = IntegerInputArgs.bind({});
+Integer_Second.args = {
+    inputType: 'Integer',
+    //type: 'number',
+    placeholder: "123",
+    value: 1,
 };

--- a/packages/planes-ds/src/lib/components/atoms/input/Input.stories.tsx
+++ b/packages/planes-ds/src/lib/components/atoms/input/Input.stories.tsx
@@ -32,7 +32,6 @@ Alphabetic.args = {
 export const Integer = IntegerInputArgs.bind({});
 Integer.args = {
     inputType: 'Integer',
-    //type: 'number',
     placeholder: "123",
     value: 1,
 };

--- a/packages/planes-ds/src/lib/components/atoms/input/integerInput.tsx
+++ b/packages/planes-ds/src/lib/components/atoms/input/integerInput.tsx
@@ -1,0 +1,65 @@
+import * as React from "react"
+import { z } from "zod"
+
+//import { cn } from "@/lib/utils"
+import { cn } from "../../../utils"
+import { useState, useEffect } from 'react';
+
+export interface InputProps
+    extends React.InputHTMLAttributes<HTMLInputElement> {
+        isRequired: boolean;
+    }
+
+const IntegerInput = React.forwardRef<HTMLInputElement, InputProps>(
+    ({ className, type, isRequired, value, ...props }, ref ) => {
+        //Zod validation with regular expressions
+        const schema = z.string().regex(/^\d*$/, 'Must be an Integer');
+        //^\d*$ meaning 
+        //"^" = start of string
+        //"\d" = is any number digit (0-9)
+        //"*" = 0 or more
+        //"$" = Final of string
+
+        //Constant using for show zod error
+        const [error, setError] = useState(null);
+        
+        const handleInputChange = (e : any) => {
+            const newValue = e.target.value;    //new value = value from input
+            //validation of value
+            try{
+                schema.parse(newValue); //zod validation
+                setError(null); //Error is null if it is correct
+                
+            }catch(err: any){
+                setError(err.message);  //If it doesn't correct
+
+            }
+        };
+    //Input Component
+    return (
+        <div>        
+        <input
+            type={type}
+            required={isRequired}
+            // value = {inputValue}
+            inputMode="numeric"
+            onBlur={handleInputChange}      //Here is the validatoin
+            className={cn(
+                "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 invalid:border-red-500",
+                className, 
+                error && "border-red-500"
+            )}
+            ref={ref}
+            {...props}
+            
+        />
+        {/* Show error in case of it exists */}
+        {error && <p>{error}</p>}   
+        </div>
+        
+    )
+    }
+)
+IntegerInput.displayName = "IntegerInput"
+
+export { IntegerInput }

--- a/packages/planes-ds/src/lib/components/atoms/input/integerInput.tsx
+++ b/packages/planes-ds/src/lib/components/atoms/input/integerInput.tsx
@@ -3,7 +3,7 @@ import { z } from "zod"
 
 //import { cn } from "@/lib/utils"
 import { cn } from "../../../utils"
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 export interface InputProps
     extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -23,11 +23,10 @@ const IntegerInput = React.forwardRef<HTMLInputElement, InputProps>(
         //Constant using for show zod error
         const [error, setError] = useState(null);
         
-        const handleInputChange = (e : any) => {
-            const newValue = e.target.value;    //new value = value from input
+        const handleInputChange = (e : React.ChangeEvent<HTMLInputElement>) => {
             //validation of value
             try{
-                schema.parse(newValue); //zod validation
+                schema.parse(e.target.value); //zod validation
                 setError(null); //Error is null if it is correct
                 
             }catch(err: any){
@@ -41,13 +40,12 @@ const IntegerInput = React.forwardRef<HTMLInputElement, InputProps>(
         <input
             type={type}
             required={isRequired}
-            // value = {inputValue}
             inputMode="numeric"
-            onBlur={handleInputChange}      //Here is the validatoin
+            onBlur={handleInputChange}      //Here is the validation
             className={cn(
                 "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 invalid:border-red-500",
                 className, 
-                error && "border-red-500"
+                error && "border-red-500"   //If we have an error, the border will change to red
             )}
             ref={ref}
             {...props}

--- a/packages/planes-ds/yarn.lock
+++ b/packages/planes-ds/yarn.lock
@@ -9809,3 +9809,8 @@ z-schema@~5.0.2:
     validator "^13.7.0"
   optionalDependencies:
     commander "^10.0.0"
+
+zod@^3.22.4:
+  version "3.22.4"
+  resolved "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
# Pull Request

## Description

I have added the Integer component with validations. If you put numbers, the component works correctly, but if you put some words or symbols, it will show an error

## Related JIRA Tickets

- https://magnimussftware.atlassian.net/browse/PLANES-15

## Changes
- Some JSON files was changed for the dependecies of zod
- I have added a new file into components folder, and input folder, named "IntegerInput.tsx"
- I added the input validation using zod

## Checklist

<!-- Mark the items that apply to this pull request. You can add more items if needed. -->

- [x] I have tested my changes thoroughly.
- [ ] I have updated the documentation to reflect the changes.
- [x] I have added unit tests (if applicable) to cover the changes.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have rebased my branch on the latest main/development branch.
- [x] All existing tests are passing.
- [x] I have run the linter and addressed any warnings or errors.
- [x] I have self-reviewed my code to catch potential issues.
- [x] I have considered the potential impact of these changes on other parts of the monorepo.
- [x] I have tested these changes in a local environment.

##Screenshots

![image](https://github.com/DuranHub/planes-monorepo/assets/94584008/287ee1cf-28eb-447f-98a6-609266ee7ba5)
![image](https://github.com/DuranHub/planes-monorepo/assets/94584008/82f173c7-e705-4a23-830e-a87863df4066)

