### PR TITLE
Add Alphabetic Input Component

### DIFF
--- a/packages/planes-ds/package-lock.json
+++ b/packages/planes-ds/package-lock.json
@@ -16,7 +16,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tailwind-merge": "^1.14.0",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@babel/core": "7.22.10",
@@ -19268,6 +19269,14 @@
       },
       "optionalDependencies": {
         "commander": "^10.0.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/packages/planes-ds/package.json
+++ b/packages/planes-ds/package.json
@@ -36,7 +36,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwind-merge": "^1.14.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@babel/core": "7.22.10",

--- a/packages/planes-ds/src/lib/components/atoms/input/alphabetic.tsx
+++ b/packages/planes-ds/src/lib/components/atoms/input/alphabetic.tsx
@@ -48,6 +48,6 @@ const AlphabeticInput = React.forwardRef<HTMLInputElement, InputProps>(
     }
 )
 
-AlphabeticInput.displayName = "AlphabeticalInput"
+AlphabeticInput.displayName = "AlphabeticInput"
 
 export { AlphabeticInput }

--- a/packages/planes-ds/src/lib/components/atoms/input/alphabetic.tsx
+++ b/packages/planes-ds/src/lib/components/atoms/input/alphabetic.tsx
@@ -1,4 +1,6 @@
 import * as React from "react"
+import { ZodError, z } from "zod";
+import { useState } from "react";
 
 //import { cn } from "@/lib/utils"
 import { cn } from "../../../utils"
@@ -10,20 +12,42 @@ export interface InputProps
 
 const AlphabeticInput = React.forwardRef<HTMLInputElement, InputProps>(
     ({ className, type, isRequired, ...props }, ref) => {
+    
+    const [error, setError] = useState(null); //Hook to manage error state
+
+    // This function is called whenever the input changes
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        // Define the schema for alphabetic input, with a regular expression for both spanish and english characters
+        const schema = z.string().regex(/^[a-zA-Z0-9\s\p{P}áéíóúÁÉÍÓÚñÑ]+$/, "Input must be alphabetic");    
+        try {
+            schema.parse(e.target.value); //If parsing is succesful, set error state to null
+            setError(null);
+        } catch (error: any) {
+            setError(error.message); //If parsing fails, set error message
+        }
+    }
+
     return (
+        <div>
         <input
             type={type}
             required={isRequired}
             className={cn(
                 "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 invalid:bg-red-500",
-                className
+                className,
+                error && "bg-red-500"
             )}
             ref={ref}
+            onBlur={handleInputChange}
             {...props}
         />
+        {/* Show error message */}
+        {error && <p>{error}</p>}
+        </div>
     )
     }
 )
-AlphabeticInput.displayName = "Input"
+
+AlphabeticInput.displayName = "AlphabeticalInput"
 
 export { AlphabeticInput }

--- a/packages/planes-ds/yarn.lock
+++ b/packages/planes-ds/yarn.lock
@@ -9809,3 +9809,8 @@ z-schema@~5.0.2:
     validator "^13.7.0"
   optionalDependencies:
     commander "^10.0.0"
+
+zod@^3.22.4:
+  version "3.22.4"
+  resolved "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
# :lipstick: Add Alphabetic Input Component

## Description

Created the Alphabetical Input component, which uses uses Zod for schema validation. The "handleInputChange" function is triggered on the blur event of the input field. If the input value does not match the defined schema, it sets an error message and applies a red background color to the input.

## Related JIRA Tickets

- https://magnimussftware.atlassian.net/browse/PLANES-29

## Changes

- Added alphabetic input component
- Added input validation using Zod library
- Installed Zod dependencies

## Checklist

<!-- Mark the items that apply to this pull request. You can add more items if needed. -->

- [x] I have tested my changes thoroughly.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added unit tests (if applicable) to cover the changes.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have rebased my branch on the latest main/development branch.
- [x] All existing tests are passing.
- [x] I have run the linter and addressed any warnings or errors.
- [x] I have self-reviewed my code to catch potential issues.
- [x] I have considered the potential impact of these changes on other parts of the monorepo.
- [x] I have tested these changes in a local environment.
