### PR TITLE
:bug: Added scrollbar to dropdown menu in combobox

### DIFF
--- a/packages/planes-ds/src/lib/components/atoms/combobox/index.tsx
+++ b/packages/planes-ds/src/lib/components/atoms/combobox/index.tsx
@@ -54,7 +54,7 @@ export function Combobox({ items, selectLabel, searchLabel, notFoundMessage, aut
             <Command>
             {autoComplete ? <CommandInput placeholder={searchLabel}/> : null}
             <CommandEmpty> {notFoundMessage} </CommandEmpty>
-            <CommandGroup>
+            <CommandGroup className="max-h-60 overflow-y-auto">
             {items.map((item) => (
                 <CommandItem
                     key={item.value}


### PR DESCRIPTION
# :bug: Added scrollbar to dropdown menu in combobox

## Description

Previoulsy, there was a bug on the combobox form, where only 16 labels would be displayed. In this code, new styles were added to the commandGroup to fix this issue, making it scrollable. 'max-h-60' sets the maximum height of the dropdown, and 'overflow-y-auto' makes the dropdown scrollable when the context exceeds the maximum height. In this case whenever 8 or more items are added to the combobox. 

## Related JIRA Tickets

- https://magnimussftware.atlassian.net/browse/PLANES-66

## Changes
- Added new styles to the CommandGroup component.
- Set a maximum height for the CommandGroup dropdown.
- Made the dropdown scrollable when the maximum height is exceeded.

## Checklist

- [x] I have tested my changes thoroughly.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added unit tests (if applicable) to cover the changes.
- [x] My code follows the project's coding standards and style guidelines.
- [x] I have rebased my branch on the latest main/development branch.
- [x] All existing tests are passing.
- [x] I have run the linter and addressed any warnings or errors.
- [x] I have self-reviewed my code to catch potential issues.
- [x] I have considered the potential impact of these changes on other parts of the monorepo.
- [x] I have tested these changes in a local environment.
